### PR TITLE
Fix for 'undefined is not an object...

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -331,8 +331,8 @@ export default class Navbar extends Component {
         style: PropTypes.object
     };
 
-    static buttonShape = PropTypes.shape(Navbar.buttonPropTypes);
-    static arrayOfButtons = PropTypes.arrayOf(Navbar.buttonShape);
+    static buttonShape = PropTypes.shape(this.constructor.buttonPropTypes);
+    static arrayOfButtons = PropTypes.arrayOf(this.constructor.buttonShape);
 
     static defaultProps = {
         statusBar: {


### PR DESCRIPTION
(evaluating 'Navbar.buttonPropTypes')

![image](https://cloud.githubusercontent.com/assets/106020/18621238/dde4f77c-7de5-11e6-8f8e-78f9227ea711.png)

"react-native": "^0.33.0",

Would not work for me until I made the proposed change.
